### PR TITLE
SJRK-182: Handle uploading of media blocks with no files

### DIFF
--- a/src/js/requestHandlers.js
+++ b/src/js/requestHandlers.js
@@ -84,10 +84,14 @@ sjrk.storyTelling.server.handleGetStory = function (request, dataSource, uploade
 
         fluid.transform(response.content, function (block) {
             if (block.blockType === "image") {
-                block.imageUrl = uploadedFilesHandlerPath + "/" + block.imageUrl;
+                if (block.imageUrl) {
+                    block.imageUrl = uploadedFilesHandlerPath + "/" + block.imageUrl;
+                }
                 return block;
             } else if (block.blockType === "audio" || block.blockType === "video") {
-                block.mediaUrl = uploadedFilesHandlerPath + "/" + block.mediaUrl;
+                if (block.mediaUrl) {
+                    block.mediaUrl = uploadedFilesHandlerPath + "/" + block.mediaUrl;
+                }
                 return block;
             }
         });
@@ -138,13 +142,15 @@ sjrk.storyTelling.server.handleSaveStoryWithBinaries = function (request, dataSo
                 return singleFile.originalname === block.fileDetails.name;
             });
 
-            if (block.blockType === "image") {
-                block.imageUrl = mediaFile.filename;
-            } else if (block.blockType === "audio" || block.blockType === "video") {
-                block.mediaUrl = mediaFile.filename;
-            }
+            if (mediaFile) {
+                if (block.blockType === "image") {
+                    block.imageUrl = mediaFile.filename;
+                } else if (block.blockType === "audio" || block.blockType === "video") {
+                    block.mediaUrl = mediaFile.filename;
+                }
 
-            binaryRenameMap[mediaFile.originalname] = mediaFile.filename;
+                binaryRenameMap[mediaFile.originalname] = mediaFile.filename;
+            }
 
             return block;
         }


### PR DESCRIPTION
This Pull Request fixes:

- https://issues.fluidproject.org/browse/SJRK-182
- https://issues.fluidproject.org/browse/SJRK-183

I've added tests to verify that we can save and retrieve:

- A blank story with all fields empty, and no blocks
- A blank story with all fields empty, plus 1 block of each type, each with all fields empty

I've also left this `TODO` comment:

```
// TODO: Generalize story testing so that components (such as request
// for retrieving saved story) and test sequences can be reused across
// different story configurations. And use these generalized pieces to
// test more story configurations.
```

I started generalizing `sjrk.storyTelling.server.testServerWithStorageDefs.testStoryPersistence` but I think it makes sense to generalize more later rather than spending the time to do it now.
